### PR TITLE
Travisci support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: python
+
+# this version of python is only used to run tox - the version specified by TOX_ENV
+# is used to install and run tests
+python: 2.7
+env:
+  - TOX_ENV=py27
+  - TOX_ENV=py32
+  - TOX_ENV=py33
+  - TOX_ENV=py34
+  - TOX_ENV=pypy
+  - TOX_ENV=coverage
+
+# command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
+install:
+  - pip install tox
+  - pip install -r dev-requirements.txt
+
+# command to run tests, e.g. python setup.py test
+script:
+  - tox -e $TOX_ENV

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,9 @@ env:
   - TOX_ENV=py27
   - TOX_ENV=py32
   - TOX_ENV=py33
+  - TOX_ENV=py34
   - TOX_ENV=pypy
   - TOX_ENV=coverage
-
-# py34 disabled due to an issue resulting in hanging builds with
-# certain versions of python 3.4 and use of httpretty
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,11 @@ env:
   - TOX_ENV=py27
   - TOX_ENV=py32
   - TOX_ENV=py33
-  - TOX_ENV=py34
   - TOX_ENV=pypy
   - TOX_ENV=coverage
+
+# py34 disabled due to an issue resulting in hanging builds with
+# certain versions of python 3.4 and use of httpretty
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Python WVA Library
 [![Build Status](https://travis-ci.org/digidotcom/python-wvalib.svg?branch=master)](https://travis-ci.org/digidotcom/python-wvalib)
 [![Latest Version](https://pypip.in/version/wva/badge.svg)](https://pypi.python.org/pypi/wva/)
 [![Supported Python versions](https://pypip.in/py_versions/wva/badge.svg)](https://pypi.python.org/pypi/wva/)
-[![License](https://pypip.in/license/devicecloud/badge.svg)](https://pypi.python.org/pypi/devicecloud/)
+[![License](https://pypip.in/license/wva/badge.svg)](https://pypi.python.org/pypi/wva/)
 
 [Full Documentation](https://digidotcom.github.io/python-wvalib)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 Python WVA Library
 ==================
 
+[![Build Status](https://travis-ci.org/digidotcom/python-wvalib.svg?branch=master)](https://travis-ci.org/digidotcom/python-wvalib)
+[![Latest Version](https://pypip.in/version/wva/badge.svg)](https://pypi.python.org/pypi/wva/)
+[![Supported Python versions](https://pypip.in/py_versions/wva/badge.svg)](https://pypi.python.org/pypi/wva/)
+[![License](https://pypip.in/license/devicecloud/badge.svg)](https://pypi.python.org/pypi/devicecloud/)
+
 [Full Documentation](https://digidotcom.github.io/python-wvalib)
 
 This library contains a set of classes and functions for performing common

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,6 +7,5 @@ pyandoc
 nose
 tox
 mock
-coverage
 sphinx
 HTTPretty==0.8.8

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,4 +8,8 @@ nose
 tox
 mock
 sphinx
-HTTPretty==0.8.8
+
+# HTTPPretty has issues with python 3.4.{1,2} in version 0.8.8
+# See http://stackoverflow.com/questions/29298455/httpretty-test-hanging-on-travis
+# and https://github.com/gabrielfalcao/HTTPretty/issues/221
+HTTPretty==0.8.6

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,6 +9,9 @@ tox
 mock
 sphinx
 
+# coveralls requires a version >=3.6,<3.999
+coverage==3.7.1
+
 # HTTPPretty has issues with python 3.4.{1,2} in version 0.8.8
 # See http://stackoverflow.com/questions/29298455/httpretty-test-hanging-on-travis
 # and https://github.com/gabrielfalcao/HTTPretty/issues/221

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ commands=nosetests
 [testenv:coverage]
 deps=
   {[testenv]deps}
-  coverage>=3.6,<3.999
   coveralls
 commands =
   coverage run --branch --omit={envdir}/* {envbindir}/nosetests


### PR DESCRIPTION
These changes add support for running the project unit tests on Travis CI.  The build results can be viewed at https://travis-ci.org/digidotcom/python-wvalib and will also be linked in the badge (the badge shows status for the master branch which is currently not available).  In addition, build status should also be shown in PRs (we'll see shortly I suppose).

@tpmanley @mikewadsten @kellyschoenhofen  Please take a look.  If all looks good I'll merge.
